### PR TITLE
Create meeting notes template

### DIFF
--- a/meetings/gen-meeting.sh
+++ b/meetings/gen-meeting.sh
@@ -1,0 +1,7 @@
+git checkout -b minutes-$(date +'%Y-%m-%d') || git checkout minutes-$(date +'%Y-%m-%d')
+git reset --hard origin/main
+git fetch origin
+git rebase origin/main
+cp template.md $(date +"%Y-%m-%d").md
+dos2unix $(date +"%Y-%m-%d").md
+git branch | grep \*

--- a/meetings/template.md
+++ b/meetings/template.md
@@ -1,0 +1,35 @@
+# TypeORM Maintainer Meeting Minutes
+
+## Present
+
+- <name> @<handle>
+
+## Agenda
+
+### Announcements
+
+- <item>
+
+### Updates
+
+- <item>
+
+### Goals
+
+- <item>
+
+## Strategic Initiatives
+
+- <item>
+
+## Action Items
+
+- @<handle> - <item>
+
+## Links
+
+- <title>: <link>
+
+## Next Meeting
+
+- Date: <date>


### PR DESCRIPTION
Based on our first meeting that took place on February 13th, 2025, we've decided to use [NodeJS TSC](https://github.com/nodejs/TSC) as an inspiration.

- The template is stored in this repository under `meetings/template.md`.
- `meetings/gen-meeting.sh` script ensures that the local and remote repositories are synchronized, and generates a `${date}.md` file, which should contain the meeting notes.
- In each meeting one attendee will be assigned to document and publish the meeting notes in this repository.

All suggestions are welcome!